### PR TITLE
Better description for CLI flags & naive loading of prefit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: cachix/cachix-action@v12
       with:
           name: histfactory-basis
-    - run: nix develop --no-update-lock-file -c make fit
+    - run: nix develop --no-update-lock-file -c make fit-nobb
 
     - uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Author: Yipeng Sun
-# Last Change: Mon Jan 31, 2022 at 06:06 PM -0500
+# Last Change: Wed Jun 07, 2023 at 12:14 AM +0800
 
 export PATH	:=	gen:$(PATH)
 
@@ -29,7 +29,13 @@ fit: inputs/* histfact_demo
 
 fit-nobb: inputs/* histfact_demo
 	histfact_demo -i inputs -o gen --useMinos=false --bbOn3D=false 2>&1 | tee ./logs/fit_$$(date +%y_%m_%d_%H%M%S).log
-  
+
+fit-nobb-load: inputs/* histfact_demo
+	histfact_demo -i inputs -o gen \
+		--useMinos=false --bbOn3D=false \
+		--loadPrefit=./gen/fit_output/saved_result.root \
+		2>&1 | tee ./logs/fit_$$(date +%y_%m_%d_%H%M%S).log
+
 fit-noshapes: inputs/* histfact_demo
 	histfact_demo -i inputs -o gen --useMinos=false --useMuShapeUncerts=false --useTauShapeUncerts=false --useDststShapeUncerts=false --bbOn3D=false 2>&1 | tee ./logs/fit_$$(date +%y_%m_%d_%H%M%S).log
 

--- a/src/histfact_demo.cpp
+++ b/src/histfact_demo.cpp
@@ -1,6 +1,6 @@
 // Author: Phoebe Hamilton, Yipeng Sun
 // License: BSD 2-clause
-// Last Change: Tue Jun 06, 2023 at 11:46 PM +0800
+// Last Change: Wed Jun 07, 2023 at 12:15 AM +0800
 
 #include <functional>
 #include <iostream>
@@ -91,7 +91,7 @@ void fixShapesDstst(ModelConfig *mc) {
 
 void loadPrefit(string &wsFilePath, RooWorkspace *ws,
                 TString wsName = "Result") {
-  cout << "Loading ALL parameters from workspace file " << wsFilePath;
+  cout << "Loading ALL parameters from workspace file " << wsFilePath << endl;
   TFile wsFile(wsFilePath.c_str());
   auto  savedWs = dynamic_cast<RooFitResult *>(wsFile.Get(wsName));
   assert(savedWs != nullptr);
@@ -103,8 +103,8 @@ void loadPrefit(string &wsFilePath, RooWorkspace *ws,
 
     if (currentArg != nullptr) {
       cout << "  Loading " << varName << endl;
-      cout << "    before: " << currentArg->getVal();
-      cout << "    after:  " << savedArg->getVal();
+      cout << "    before: " << currentArg->getVal() << endl;
+      cout << "    after:  " << savedArg->getVal() << endl;
       currentArg->setVal(savedArg->getVal());
     }
   }
@@ -316,6 +316,16 @@ void fit(ArgProxy params, Config addParams) {
   result->correlationMatrix().Print();
   printf("Stopwatch: fit ran in %f seconds with %f seconds in prep\n",
          swFit.RealTime(), swPrep.RealTime());
+
+  if (result != nullptr) {
+    cout << "Saving fit result..." << endl;
+    TFile fitResultFile(outputDir + "/fit_output/saved_result.root",
+                        "RECREATE");
+    fitResultFile.cd();
+    fitResultFile.Add(result);
+    fitResultFile.Write();
+    fitResultFile.Close();
+  }
 
   cout << "DEBUG: AFTER FIT:" << endl;
   cout << data->sumEntries() << " data, \t" << model->expectedEvents(obs)

--- a/src/histfact_demo.cpp
+++ b/src/histfact_demo.cpp
@@ -1,6 +1,6 @@
 // Author: Phoebe Hamilton, Yipeng Sun
 // License: BSD 2-clause
-// Last Change: Tue Jun 06, 2023 at 11:38 PM +0800
+// Last Change: Tue Jun 06, 2023 at 11:46 PM +0800
 
 #include <functional>
 #include <iostream>
@@ -166,7 +166,21 @@ void fit(ArgProxy params, Config addParams) {
   // Change fit parameters //
   ///////////////////////////
 
+  // FIXME: from https://github.com/root-project/root/issues/12729#issuecomment-1527829256
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 28, 00)
   auto ws = RooStats::HistFactory::MakeModelAndMeasurementFast(meas);
+#else
+  // Disable the binned fit optimization that was enabled by default in
+  // ROOT 6.28. This optimization skips the normalization of the RooRealSumPdf,
+  // because the unnormalized bin contents already represent the yields that can
+  // be used by the RooNLLVar to sum the Poisson terms. However, this
+  // optimization doesn't work for this demo, maybe because it's not compatible
+  // with the RooBarlowBeestonLL. See also
+  // https://root.cern/doc/v628/release-notes.html.
+  HistoToWorkspaceFactoryFast::Configuration cfg;
+  cfg.binnedFitOptimization = false;
+  auto ws = RooStats::HistFactory::MakeModelAndMeasurementFast(meas, cfg);
+#endif
 
   // Get model manually
   auto mc    = static_cast<ModelConfig *>(ws->obj("ModelConfig"));


### PR DESCRIPTION
@CoffeeIntoScience I've updated some description of the CLI flags to (hopefully) make them clearer/correct. I've also implemented saving fit result (`RooFitResult`) to a file and optionally loading fitted params via a `loadPrefit=<path_to_fit_result>` CLI flag.